### PR TITLE
Improve handling of profile defaults

### DIFF
--- a/nova/lib/configuration.js
+++ b/nova/lib/configuration.js
@@ -10,6 +10,7 @@ function loadConfiguration() {
                 keyPrefix: '',
             },
         },
+        profiles: {},
 
         get: function(domain, profile) {
             var cfg = this.default[domain];


### PR DESCRIPTION
If no profiles exist in the .novacfg, fall back to the default always.
