### PR TITLE
Allow for artifacts that don't specify a path for uploading to S3

### DIFF
--- a/nova/lib/commands/build.js
+++ b/nova/lib/commands/build.js
@@ -86,9 +86,9 @@ Command.prototype.execute = function() {
         if (config.commonOptions.verbose) {
             console.log('Ensuring buckets are full...');
         }
-        var regions = _.uniq(_.map(that.project.config.artifacts, function(artifact) {
+        var regions = _.compact(_.uniq(_.map(that.project.config.artifacts, function(artifact) {
             return artifact.region;
-        }));
+        })));
 
         // ensure there are buckets in right regions
         var s3config = config.get('s3');
@@ -190,6 +190,10 @@ Command.prototype.execute = function() {
             dateString);
 
         var promises = _.map(buildConfig.artifacts, function(artifact) {
+            if (!artifact.path) {
+                return;
+            }
+
             var baseName = path.basename(artifact.path);
             var keyPath = keyPathBase + '/' + baseName;
             var readStream = fs.createReadStream(artifact.path);
@@ -227,7 +231,7 @@ Command.prototype.execute = function() {
             });
         });
 
-        return q.all(promises).then(function(results) {
+        return q.all(_.compact(promises)).then(function(results) {
             return _.extend(buildConfig, {
                 artifacts: results,
             });


### PR DESCRIPTION
By not passing a path to the done() callback,, an artifact is declaring
that there's no output to upload to S3. This is handy for artifacts
that have their own storage (like docker images).

As a result it's also not necessary to specify a region/bucket.
