### PR TITLE
Make debugging a bit easier

### DIFF
--- a/nova/lib/commands/deploy.js
+++ b/nova/lib/commands/deploy.js
@@ -374,7 +374,8 @@ Command.prototype.execute = function() {
 
         var parameters = _.map(deploymentConfig.buildResult.parameters, function(paramObject){
             if (paramObject.value === null || typeof paramObject.value === 'undefined') {
-                throw new Error('Parameter values cannot be null')
+                throw new Error('Parameter values for \'' + paramObject.param.name
+                    + '\' cannot be null');
             }
             return {
                 ParameterKey: paramObject.param.name,


### PR DESCRIPTION
When you get an error message saying that "Parameter values cannot be null"
it can be hard to know what parameter values we're talking about ;)
